### PR TITLE
Add Transition class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
 script:
   - find examples include tests \(  -name "*.cc" -o -name "*.h" \) -exec clang-format -i {} \;
   - git update-index --really-refresh
+  - git --no-pager diff
   - mkdir -p build
   - cd build
   - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     fast_finish: true
 
 script:
-  - find examples include tests \(  -name "*.cc" -o -name "*.h" \) -exec clang-format -i {} \;
+  - find examples include tests \(  -name "*.cc" -o -name "*.h" \) -exec clang-format-8 -i {} \;
   - git update-index --really-refresh
   - git --no-pager diff
   - mkdir -p build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ set(COMMON_CXX_OPTIONS
     -Wpedantic
     -Wconversion
     -Wsign-conversion
-    -Wnull-dereference
     -Wdouble-promotion
     -Wformat=2
 )
@@ -29,16 +28,23 @@ set(CLANG_CXX_OPTIONS
 
 set(GCC_CXX_OPTIONS
     ${COMMON_CXX_OPTIONS}
-    -Wduplicated-cond
-    -Wduplicated-branches
     -Wlogical-op
     -Wuseless-cast
-    -Wmisleading-indentation
 )
 
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(DEFAULT_CXX_OPTIONS ${CLANG_CXX_OPTIONS})
+    set(DEFAULT_CXX_OPTIONS ${CLANG_CXX_OPTIONS} -Wnull-dereference)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+        set(GCC_CXX_OPTIONS ${GCC_CXX_OPTIONS} -Wno-shadow)
+    endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
+        set(GCC_CXX_OPTIONS ${GCC_CXX_OPTIONS}
+            -Wduplicated-cond
+            -Wduplicated-branches
+            -Wmisleading-indentation)
+    endif()
     set(DEFAULT_CXX_OPTIONS ${GCC_CXX_OPTIONS})
 endif()
 

--- a/include/state_machine.h
+++ b/include/state_machine.h
@@ -1,1 +1,19 @@
 #pragma once
+
+#include "state_machine/transition.h"
+
+namespace state_machine {
+
+using transition::make_transition;
+
+namespace placeholder {
+constexpr auto _ = transition::empty_placeholder;
+} // namespace placeholder
+
+template <class T>
+constexpr auto state = transition::State<T>{};
+
+template <class E>
+constexpr auto event = transition::Event<E>{};
+
+} // namespace state_machine

--- a/include/state_machine/backport.h
+++ b/include/state_machine/backport.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <type_traits>
 
 namespace state_machine {
@@ -35,6 +36,13 @@ using void_t = void;
 // Backport std::bool_constant (C++17)
 template <bool B>
 using bool_constant = std::integral_constant<bool, B>;
+
+// Backport std::is_invocable_r (C++17)
+// https://stackoverflow.com/questions/51187974/can-stdis-invocable-be-emulated-within-c11
+template <typename R, typename F, typename... Args>
+struct is_invocable_r
+    : std::is_constructible<std::function<R(Args...)>,
+                            std::reference_wrapper<typename std::remove_reference<F>::type>> {};
 
 } // namespace stdx
 } // namespace state_machine

--- a/include/state_machine/containers/mapping.h
+++ b/include/state_machine/containers/mapping.h
@@ -55,7 +55,8 @@ struct surjection : inheritor<Ts...> {
     static constexpr auto at_key_impl(std::pair<Key, Value>*) -> Value;
 
     template <class Key, class Default = void>
-    using at_key = decltype(at_key_impl<Key, Default>(std::declval<inheritor<Ts...>*>()));
+    using at_key =
+        decltype(surjection::at_key_impl<Key, Default>(std::declval<inheritor<Ts...>*>()));
 
     template <class Key>
     using contains_key = negation<std::is_same<void, at_key<Key>>>;
@@ -80,7 +81,8 @@ struct bijection : surjection<Ts...> {
     static constexpr auto at_value_impl(std::pair<Key, Value>*) -> Key;
 
     template <class Value, class Default = void>
-    using at_value = decltype(at_value_impl<Value, Default>(std::declval<inheritor<Ts...>*>()));
+    using at_value =
+        decltype(bijection::at_value_impl<Value, Default>(std::declval<inheritor<Ts...>*>()));
 
     template <class Value>
     using contains_value = negation<std::is_same<void, at_value<Value>>>;

--- a/include/state_machine/transition.h
+++ b/include/state_machine/transition.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "state_machine/containers.h"
+#include "state_machine/traits.h"
+
+#include <type_traits>
+#include <utility>
+
+namespace state_machine {
+namespace transition {
+
+using ::state_machine::containers::basic::identity;
+
+template <class T>
+struct State {
+    using type = T;
+};
+
+template <class T>
+struct Event {
+    using type = T;
+};
+
+namespace detail {
+
+template <class T>
+struct is_state : aux::is_specialization_of<State, std::decay_t<T>> {};
+
+template <class T>
+struct is_event : aux::is_specialization_of<Event, std::decay_t<T>> {};
+
+template <class Result, class Callable, class Source, class Event>
+using is_transition_callable =
+    stdx::conjunction<stdx::negation<std::is_null_pointer<Callable>>,
+                      stdx::disjunction<stdx::is_invocable_r<Result, Callable>,
+                                        stdx::is_invocable_r<Result, Callable, Event>,
+                                        stdx::is_invocable_r<Result, Callable, Source>,
+                                        stdx::is_invocable_r<Result, Callable, Source, Event>>>;
+
+template <class T>
+using as_action_arg = std::add_lvalue_reference_t<T>;
+
+template <class T>
+using as_guard_arg = std::add_const_t<as_action_arg<T>>;
+
+template <class Callable, class Source, class Event>
+using is_guard = is_transition_callable<bool, Callable, as_guard_arg<Source>, as_guard_arg<Event>>;
+
+template <class Result, class Callable, class Source, class Event>
+using is_action =
+    is_transition_callable<Result, Callable, as_action_arg<Source>, as_action_arg<Event>>;
+
+} // namespace detail
+
+template <class Source, class Event, class Guard, class Action, class Destination>
+struct Transition : Guard, Action {
+    static_assert(detail::is_state<Source>::value,
+                  "`Source` type parameter must be a specialization of `State`.");
+    static_assert(detail::is_event<Event>::value,
+                  "`Event` type parameter must be a specialization of `Event`.");
+    static_assert(detail::is_state<Destination>::value,
+                  "`Destination` type parameter must be a specialization of `State`.");
+
+    using type = Transition<Source, Event, Guard, Action, Destination>;
+    using key_type = std::pair<Source, Event>;
+    using source_type = typename Source::type;
+    using event_type = typename Event::type;
+    using guard_type = Guard;
+    using action_type = Action;
+    using destination_type = typename Destination::type;
+    static constexpr bool internal = std::is_void<destination_type>::value;
+
+    static_assert(
+        detail::is_guard<Guard, source_type, event_type>::value,
+        "`Guard` type parameter must be callable with `Source` and/or `Event` and return bool.");
+    static_assert(detail::is_action<destination_type, Action, source_type, event_type>::value,
+                  "`Action` type parameter must be callable with `Source` and/or `Event` and "
+                  "return `Destination`.");
+
+    // We should also check if `Guard` is constexpr and returns true,
+    // but we assume it to be the case if `Guard` is convertible to a
+    // stateless function that takes no arguments and returns a bool.
+    static constexpr auto has_empty_guard = std::is_convertible<Guard, bool (*)(void)>::value;
+
+    constexpr Transition(Guard&& guard, Action&& action)
+        : Guard{std::forward<Guard>(guard)}, Action{std::forward<Action>(action)} {}
+
+    template <typename... Ts>
+    auto guard(Ts&&... ts) const noexcept(noexcept(Guard::operator()(std::forward<Ts>(ts)...)))
+        -> bool {
+        return Guard::operator()(std::forward<Ts>(ts)...);
+    }
+
+    template <typename... Ts>
+    auto action(Ts&&... ts) const noexcept(noexcept(Action::operator()(std::forward<Ts>(ts)...)))
+        -> destination_type {
+        return Action::operator()(std::forward<Ts>(ts)...);
+    }
+};
+
+
+namespace detail {
+
+struct empty {};
+
+} // namespace detail
+
+constexpr auto empty_placeholder = identity<detail::empty>{};
+
+namespace detail {
+
+template <class T>
+struct is_empty_placeholder
+    : std::is_same<std::decay_t<decltype(empty_placeholder)>, std::decay_t<T>> {};
+
+template <class Guard, std::enable_if_t<!is_empty_placeholder<Guard>::value, int> = 0>
+auto create_guard_if_empty(Guard&& guard) {
+    return std::forward<Guard>(guard);
+}
+
+template <class Guard, std::enable_if_t<is_empty_placeholder<Guard>::value, int> = 0>
+auto create_guard_if_empty(Guard&&) {
+    return [] { return true; };
+}
+
+template <class Action, std::enable_if_t<!is_empty_placeholder<Action>::value, int> = 0>
+auto create_action_if_empty(Action&& action) {
+    return std::forward<Action>(action);
+}
+
+template <class Action, std::enable_if_t<is_empty_placeholder<Action>::value, int> = 0>
+auto create_action_if_empty(Action&&) {
+    return [] {};
+}
+
+} // namespace detail
+
+template <class Source, class Event, class Guard, class Action, class Destination>
+constexpr auto make_transition(Source, Event, Guard&& guard, Action&& action, Destination) {
+    auto updated_guard = detail::create_guard_if_empty(std::forward<Guard>(guard));
+    using UpdatedGuard = decltype(updated_guard);
+
+    auto updated_action = detail::create_action_if_empty(std::forward<Action>(action));
+    using UpdatedAction = decltype(updated_action);
+
+    using UpdatedDestination = std::
+        conditional_t<detail::is_empty_placeholder<Destination>::value, State<void>, Destination>;
+
+    return Transition<Source, Event, UpdatedGuard, UpdatedAction, UpdatedDestination>{
+        std::forward<UpdatedGuard>(updated_guard), std::forward<UpdatedAction>(updated_action)};
+}
+
+} // namespace transition
+} // namespace state_machine

--- a/include/state_machine/transition.h
+++ b/include/state_machine/transition.h
@@ -86,14 +86,15 @@ struct Transition : Guard, Action {
         : Guard{std::forward<Guard>(guard)}, Action{std::forward<Action>(action)} {}
 
     template <typename... Ts>
-    auto guard(Ts&&... ts) const noexcept(noexcept(Guard::operator()(std::forward<Ts>(ts)...)))
-        -> bool {
+    auto guard(Ts&&... ts) const
+        noexcept(noexcept(std::declval<Guard>().operator()(std::forward<Ts>(ts)...))) -> bool {
         return Guard::operator()(std::forward<Ts>(ts)...);
     }
 
     template <typename... Ts>
-    auto action(Ts&&... ts) const noexcept(noexcept(Action::operator()(std::forward<Ts>(ts)...)))
-        -> destination_type {
+    auto action(Ts&&... ts) const
+        noexcept(noexcept(std::declval<Action>().operator()(std::forward<Ts>(ts)...)))
+            -> destination_type {
         return Action::operator()(std::forward<Ts>(ts)...);
     }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,9 @@ package_add_test(test_traits
 package_add_test(test_containers
     test_containers.cc)
 
+package_add_test(test_transition
+    test_transition.cc)
+
 package_add_test(test_variant
     test_variant.cc)
 

--- a/tests/test_transition.cc
+++ b/tests/test_transition.cc
@@ -1,0 +1,128 @@
+#include "state_machine.h"
+
+#include "gtest/gtest.h"
+#include <type_traits>
+
+namespace {
+using ::state_machine::event;
+using ::state_machine::make_transition;
+using ::state_machine::state;
+using ::state_machine::placeholder::_;
+
+struct s1 {};
+struct s2 {};
+
+struct e1 {};
+struct e2 {
+    e2(int x) : value{x} {}
+    int value;
+};
+
+} // namespace
+
+TEST(transition, complete) {
+    auto transition = make_transition(
+        state<s1>,
+        event<e1>,
+        [](const auto& s, const auto& e) {
+            (void)s;
+            (void)e;
+            return true;
+        },
+        [](auto& s, auto& e) {
+            (void)s;
+            (void)e;
+            return s2{};
+        },
+        state<s2>);
+
+    EXPECT_EQ(transition.guard(s1{}, e1{}), true);
+
+    auto s = s1{};
+    auto e = e1{};
+    static_assert(std::is_same<decltype(transition.action(s, e)), s2>::value, "");
+}
+
+TEST(transition, empty_guard) {
+    auto transition = make_transition(
+        state<s1>,
+        event<e1>,
+        _,
+        [](auto& s, auto& e) {
+            (void)s;
+            (void)e;
+            return s2{};
+        },
+        state<s2>);
+
+    EXPECT_EQ(transition.guard(), true);
+
+    auto s = s1{};
+    auto e = e1{};
+    static_assert(std::is_same<decltype(transition.action(s, e)), s2>::value, "");
+}
+
+TEST(transition, empty_dest) {
+    auto transition = make_transition(
+        state<s1>, event<e1>, [] { return true; }, [] {}, _);
+
+    EXPECT_EQ(transition.guard(), true);
+    static_assert(std::is_same<decltype(transition.action()), void>::value, "");
+}
+
+TEST(transition, empty_action_dest) {
+    auto transition = make_transition(
+        state<s1>, event<e1>, [] { return true; }, _, _);
+
+    EXPECT_EQ(transition.guard(), true);
+    static_assert(std::is_same<decltype(transition.action()), void>::value, "");
+}
+
+TEST(transition, empty_guard_action_dest) {
+    auto transition = make_transition(state<s1>, event<e1>, _, _, _);
+
+    EXPECT_EQ(transition.guard(), true);
+    static_assert(std::is_same<decltype(transition.action()), void>::value, "");
+}
+
+TEST(transition, transition_size_empty_base_optimization) {
+    auto transition = make_transition(
+        state<s1>,
+        event<e1>,
+        [](const auto& s, const auto& e) {
+            (void)s;
+            (void)e;
+            return true;
+        },
+        [](auto& s, auto& e) {
+            (void)s;
+            (void)e;
+            return s2{};
+        },
+        state<s2>);
+
+    static_assert(sizeof(transition) == 1, "");
+}
+
+TEST(transition, transition_size_guard_capture_int) {
+    int x = 42;
+
+    auto transition = make_transition(
+        state<s1>, event<e2>, [x](const auto& e) { return e.value > x; }, []() { return s2{}; }, state<s2>);
+
+    static_assert(sizeof(transition) == sizeof(x), "");
+}
+
+TEST(transition, guard_moved_into_transition_size) {
+    static constexpr int threshold = 42;
+
+    auto transition = make_transition(
+        state<s1>,
+        event<e2>,
+        [x = std::make_unique<int>(threshold)](const e2 e) { return e.value > *x; },
+        _,
+        _);
+
+    EXPECT_FALSE(transition.guard(e2{threshold}));
+    EXPECT_TRUE(transition.guard(e2{threshold + 1}));
+}

--- a/tests/test_transition.cc
+++ b/tests/test_transition.cc
@@ -108,7 +108,11 @@ TEST(transition, transition_size_guard_capture_int) {
     int x = 42;
 
     auto transition = make_transition(
-        state<s1>, event<e2>, [x](const auto& e) { return e.value > x; }, []() { return s2{}; }, state<s2>);
+        state<s1>,
+        event<e2>,
+        [x](const auto& e) { return e.value > x; },
+        []() { return s2{}; },
+        state<s2>);
 
     static_assert(sizeof(transition) == sizeof(x), "");
 }


### PR DESCRIPTION
Add Transition class to represent a state machine transition for a given
state and event pair. A transition can contain a guard, which determines
if a transition is triggered. On trigger, an associated action is
invoked which creates the destination state.

When creating transitions, an empty placeholder can be used as a
substitute for default values. An empty guard is converted into a guard
function that always triggers the transition. An empty destination
represents an internal state transition[1]. An empty action can be used
with an empty destination.

[1]: https://en.wikipedia.org/wiki/UML_state_machine#Internal_transitions